### PR TITLE
Default browser bugfix for API 23+

### DIFF
--- a/library/src/main/java/org/chromium/customtabsclient/CustomTabsHelper.java
+++ b/library/src/main/java/org/chromium/customtabsclient/CustomTabsHelper.java
@@ -11,6 +11,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -78,7 +79,12 @@ public class CustomTabsHelper {
         }
 
         // Get all apps that can handle VIEW intents.
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<ResolveInfo> resolvedActivityList;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
+        } else {
+            resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_DEFAULT_ONLY);
+        }
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             Intent serviceIntent = new Intent();

--- a/library/src/main/java/org/chromium/customtabsclient/CustomTabsHelper.java
+++ b/library/src/main/java/org/chromium/customtabsclient/CustomTabsHelper.java
@@ -83,7 +83,7 @@ public class CustomTabsHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
         } else {
-            resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_DEFAULT_ONLY);
+            resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
         }
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {


### PR DESCRIPTION
On Marshmallow and later, `queryIntentActivities` will by default **_only_** return the default browser for an HTTP URL, if one is set. To override that behavior, the `MATCH_ALL` parameter must be used. 

To verify, install Firefox and Chrome on an API 23+ device, and set Firefox to be the default browser. When you launch the unpatched sample app, the link will open in Firefox, which currently doesn't support custom tabs. The patched version will be able to see both Firefox and Chrome, and will correctly select Chrome, since it implements custom tabs.

This is also a bug in the upstream sample, [with a long-ignored fix](https://github.com/GoogleChrome/custom-tabs-client/pull/25).